### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/4og/zserio-language-support/security/code-scanning/1](https://github.com/4og/zserio-language-support/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. Since the workflow only checks out code and runs tests, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow file (above `jobs:`), which will apply to all jobs unless overridden. This change should be made in `.github/workflows/build.yml` above the `jobs:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
